### PR TITLE
Implementing some unit tests for the modules in this library

### DIFF
--- a/sq_python_helpers/FundUsingFriendbot.py
+++ b/sq_python_helpers/FundUsingFriendbot.py
@@ -2,10 +2,10 @@ import requests
 
 def fund_using_friendbot(public_key: str) -> requests.Response:
     """Use friendbot to ensure a testnet account exists and is funded.
-    
+
     Args:
         public_key: The public key to test, and fund if necessary.
-        
+
     Returns:
         HTTP response object from the funding operation.
     """
@@ -16,3 +16,5 @@ def fund_using_friendbot(public_key: str) -> requests.Response:
         response = requests.get( url, params={'addr': public_key} )
         response.raise_for_status()
         return response
+    else:
+        return r

--- a/test/fixtures/friendbot_successful.json
+++ b/test/fixtures/friendbot_successful.json
@@ -1,0 +1,52 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/transactions/be3ed0472995cc33619a0aa77039f4eaaf74e38ea2d66629b1ff5b5ca69ca255"
+    },
+    "account": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GC27G66JXEOSTGR5RWTVG2WOT7GHQ3CPK672KJJADZGZZDYIPJEH6QV4"
+    },
+    "ledger": {
+      "href": "https://horizon-testnet.stellar.org/ledgers/1378553"
+    },
+    "operations": {
+      "href": "https://horizon-testnet.stellar.org/transactions/be3ed0472995cc33619a0aa77039f4eaaf74e38ea2d66629b1ff5b5ca69ca255/operations{?cursor,limit,order}",
+      "templated": true
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/transactions/be3ed0472995cc33619a0aa77039f4eaaf74e38ea2d66629b1ff5b5ca69ca255/effects{?cursor,limit,order}",
+      "templated": true
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=5920840050806784"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=5920840050806784"
+    },
+    "transaction": {
+      "href": "https://horizon-testnet.stellar.org/transactions/be3ed0472995cc33619a0aa77039f4eaaf74e38ea2d66629b1ff5b5ca69ca255"
+    }
+  },
+  "id": "be3ed0472995cc33619a0aa77039f4eaaf74e38ea2d66629b1ff5b5ca69ca255",
+  "paging_token": "5920840050806784",
+  "successful": true,
+  "hash": "be3ed0472995cc33619a0aa77039f4eaaf74e38ea2d66629b1ff5b5ca69ca255",
+  "ledger": 1378553,
+  "created_at": "2021-06-09T05:46:17Z",
+  "source_account": "GC27G66JXEOSTGR5RWTVG2WOT7GHQ3CPK672KJJADZGZZDYIPJEH6QV4",
+  "source_account_sequence": "4308745551085653",
+  "fee_account": "GC27G66JXEOSTGR5RWTVG2WOT7GHQ3CPK672KJJADZGZZDYIPJEH6QV4",
+  "fee_charged": "100",
+  "max_fee": "100000",
+  "operation_count": 1,
+  "envelope_xdr": "AAAAAgAAAAC183vJuR0pmj2Np1Nqzp/MeGxPV7+lJSAeTZyPCHpIfwABhqAAD07IAAAAVQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAAAAAAABpF/+0aD1upOhS8tDKjMDLKdJ7FiedHklpoQ+QZK1BYgAAABdIdugAAAAAAAAAAAIIekh/AAAAQGt9lWJ8y96VNq68VKn7iw+b18XZziyP00T5svzbjY/qDfwfuYHJcyRSvKrZAYbYKZUWmn/ux1bV0nrng/4VlA6GVuCcAAAAQIh0d8qZfJbak3Ry2qAVjb+LcchFDSO7FPjIT7N7DOdg9vb/dDJqgoo9W8Ng7NI493qkE1+os+z2R0618r29egk=",
+  "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+  "result_meta_xdr": "AAAAAgAAAAIAAAADABUI+QAAAAAAAAAAtfN7ybkdKZo9jadTas6fzHhsT1e/pSUgHk2cjwh6SH8AAAAAPCxh4AAPTsgAAABUAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABABUI+QAAAAAAAAAAtfN7ybkdKZo9jadTas6fzHhsT1e/pSUgHk2cjwh6SH8AAAAAPCxh4AAPTsgAAABVAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMAFQjqAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAC5OdPGDBKaAAAAvwAAAtQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAFQj5AAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAC5Obx9lSqaAAAAvwAAAtQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAFQj5AAAAAAAAAABpF/+0aD1upOhS8tDKjMDLKdJ7FiedHklpoQ+QZK1BYgAAABdIdugAABUI+QAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  "fee_meta_xdr": "AAAAAgAAAAMAFO2nAAAAAAAAAAC183vJuR0pmj2Np1Nqzp/MeGxPV7+lJSAeTZyPCHpIfwAAAAA8LGJEAA9OyAAAAFQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAFQj5AAAAAAAAAAC183vJuR0pmj2Np1Nqzp/MeGxPV7+lJSAeTZyPCHpIfwAAAAA8LGHgAA9OyAAAAFQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+  "memo_type": "none",
+  "signatures": [
+    "a32VYnzL3pU2rrxUqfuLD5vXxdnOLI/TRPmy/NuNj+oN/B+5gclzJFK8qtkBhtgplRaaf+7HVtXSeueD/hWUDg==",
+    "iHR3ypl8ltqTdHLaoBWNv4txyEUNI7sU+MhPs3sM52D29v90MmqCij1bw2Ds0jj3eqQTX6iz7PZHTrXyvb16CQ=="
+  ],
+  "valid_after": "1970-01-01T00:00:00Z"
+}

--- a/test/fixtures/funded_account.json
+++ b/test/fixtures/funded_account.json
@@ -1,0 +1,71 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV"
+    },
+    "transactions": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV/transactions{?cursor,limit,order}",
+      "templated": true
+    },
+    "operations": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV/operations{?cursor,limit,order}",
+      "templated": true
+    },
+    "payments": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV/payments{?cursor,limit,order}",
+      "templated": true
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV/effects{?cursor,limit,order}",
+      "templated": true
+    },
+    "offers": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV/offers{?cursor,limit,order}",
+      "templated": true
+    },
+    "trades": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV/trades{?cursor,limit,order}",
+      "templated": true
+    },
+    "data": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV/data/{key}",
+      "templated": true
+    }
+  },
+  "id": "GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV",
+  "account_id": "GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV",
+  "sequence": "5919212258197504",
+  "subentry_count": 0,
+  "last_modified_ledger": 1378174,
+  "last_modified_time": "2021-06-09T05:12:55Z",
+  "thresholds": {
+    "low_threshold": 0,
+    "med_threshold": 0,
+    "high_threshold": 0
+  },
+  "flags": {
+    "auth_required": false,
+    "auth_revocable": false,
+    "auth_immutable": false,
+    "auth_clawback_enabled": false
+  },
+  "balances": [
+    {
+      "balance": "10000.0000000",
+      "buying_liabilities": "0.0000000",
+      "selling_liabilities": "0.0000000",
+      "asset_type": "native"
+    }
+  ],
+  "signers": [
+    {
+      "weight": 1,
+      "key": "GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV",
+      "type": "ed25519_public_key"
+    }
+  ],
+  "data": {},
+  "num_sponsoring": 0,
+  "num_sponsored": 0,
+  "paging_token": "GDXAC3SQPV2UAUU7MTFQH5RBNNQBRWVMS5IFF3ZXDUJT5DUQ25PW2XHV"
+}

--- a/test/fixtures/testnet_ledger.json
+++ b/test/fixtures/testnet_ledger.json
@@ -1,0 +1,57 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=\u0026limit=1\u0026order=desc"
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=5956183336681472\u0026limit=1\u0026order=desc"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/ledgers?cursor=5956183336681472\u0026limit=1\u0026order=asc"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1386782"
+          },
+          "transactions": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1386782/transactions{?cursor,limit,order}",
+            "templated": true
+          },
+          "operations": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1386782/operations{?cursor,limit,order}",
+            "templated": true
+          },
+          "payments": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1386782/payments{?cursor,limit,order}",
+            "templated": true
+          },
+          "effects": {
+            "href": "https://horizon-testnet.stellar.org/ledgers/1386782/effects{?cursor,limit,order}",
+            "templated": true
+          }
+        },
+        "id": "7de3330d245f80c67f2ecef336fac24c16044d0aca7a698dee20e353e785d12b",
+        "paging_token": "5956183336681472",
+        "hash": "7de3330d245f80c67f2ecef336fac24c16044d0aca7a698dee20e353e785d12b",
+        "prev_hash": "ae2a733d37047be8a53f0eaeaff5cb96057695e2d750accc624b157f394f0157",
+        "sequence": 1386782,
+        "successful_transaction_count": 3,
+        "failed_transaction_count": 1,
+        "operation_count": 13,
+        "tx_set_operation_count": 15,
+        "closed_at": "2021-06-09T17:46:25Z",
+        "total_coins": "100000000000.0000000",
+        "fee_pool": "14703.0361171",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 5000000,
+        "max_tx_set_size": 105,
+        "protocol_version": 17,
+        "header_xdr": "AAAAEa4qcz03BHvopT8Orq/1y5YFdpXi11CszGJLFX85TwFX+XXQOkjVJs1OL9sVs4fyKo4jTeog/Z1uRFBiCLBafP0AAAAAYMD+cQAAAAAAAAABAAAAALVdELK7fShO1cA6R6XhtZDJD1eDVUccxFB7voIE0jyLAAAAQL1qzcx7W9IBZ6qd11uP39YFjcnXV568ktBg0NnNaGvCWQ7tDmxbXGvQ72iDdD9ZHW7AGxh6SNv/BjbjWm+EKwRS97a4D8JrIR0yDCvN5INkm4qbdcv1VEdQ5S1obEVY4v3JbQpCDKAljRwB4oWtvbALzpcHhN4A01DraO79vSLTABUpHg3gtrOnZAAAAAAAIjuxRFMAAAAAAAAAAABIbcQAAABkAExLQAAAAGmb/1LGfonu7ODzaXBiWPHb+ng6gr80v+Wlk81vz9cxriTpaS5PzG/yEAYhRsSv8XB0F58hSu/YwwIZK7Oj4eDnhOAUk+t8gVN5AaCvTbuFH5C/Ap7NWBpRNN6FkVJsuS325zgzPILPqseSKG34vOiiMfae4KOBf45aWUj8lGx78QAAAAA="
+      }
+    ]
+  }
+}

--- a/test/fixtures/unfunded_account.json
+++ b/test/fixtures/unfunded_account.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://stellar.org/horizon-errors/not_found",
+  "title": "Resource Missing",
+  "status": 404,
+  "detail": "The resource at the url requested was not found.  This usually occurs for one of two reasons:  The url requested is not valid, or no data in our database could be found with the parameters provided."
+}

--- a/test/test_FundUsingFriendbot.py
+++ b/test/test_FundUsingFriendbot.py
@@ -1,0 +1,45 @@
+"""
+Test module sq_python_helpers.FundUsingFriendbot
+"""
+import json
+import requests
+import requests_mock
+from unittest import TestCase
+from stellar_sdk import Keypair, Server, Network, Account
+
+from sq_python_helpers.FundUsingFriendbot import fund_using_friendbot
+
+class FundUsingFriendbotTestCase(TestCase):
+    def setUp(self) -> None:
+        with open("test/fixtures/funded_account.json", "r") as fixture_file:
+            self.funded_account = json.load(fixture_file)
+        with open("test/fixtures/unfunded_account.json", "r") as fixture_file:
+            self.unfunded_account = json.load(fixture_file)
+        with open("test/fixtures/friendbot_successful.json", "r") as fixture_file:
+            self.friendbot_successful = json.load(fixture_file)
+        self.k = Keypair.random()
+
+    @requests_mock.Mocker()
+    def test_account_already_exists(self, m: requests_mock.Mocker):
+        m.get(f"https://horizon-testnet.stellar.org/accounts/{self.k.public_key}",
+              json=self.funded_account)
+        r = fund_using_friendbot(self.k.public_key)
+        self.assertIsInstance(r, requests.Response,
+                              "item returned is not a response object")
+        self.assertIsNotNone(r.json()["account_id"],
+                             "response is missing 'account_id'")
+        self.assertGreaterEqual(float(r.json()["balances"][0]["balance"]), 1,
+                                "native balance is less than 1")
+
+
+    @requests_mock.Mocker()
+    def test_account_not_funded(self, m: requests_mock.Mocker):
+        m.get(f"https://horizon-testnet.stellar.org/accounts/{self.k.public_key}",
+              json=self.unfunded_account, status_code=404)
+        m.get(f"https://friendbot.stellar.org/?addr={self.k.public_key}",
+              json=self.friendbot_successful)
+        r = fund_using_friendbot(self.k.public_key)
+        self.assertIsInstance(r, requests.Response,
+                              "item returned is not a response object")
+        self.assertTrue(r.json()["successful"],
+                        "funding transaction was unsuccessful")

--- a/test/test_GenerateKeypair.py
+++ b/test/test_GenerateKeypair.py
@@ -1,0 +1,29 @@
+"""
+Test module sq_python_helpers.GenerateKeypair
+"""
+from unittest import TestCase
+from stellar_sdk import Keypair
+
+from sq_python_helpers.GenerateKeypair import generate_keypair
+
+class GenerateKeypairTestCase(TestCase):
+    def setUp(self) -> None:
+        self.k = generate_keypair()
+
+    def test_return_three_items(self):
+        self.assertEqual(len(self.k), 3,
+                         'wrong number of items returned')
+
+    def test_return_expected_types(self):
+        self.assertIsInstance(self.k[0], str,
+                              'first item is not a string')
+        self.assertIsInstance(self.k[1], str,
+                              'second item is not a string')
+        self.assertIsInstance(self.k[2], Keypair,
+                              'third item is not a Keypair object')
+
+    def test_public_secret_keypair_match(self):
+        self.assertEqual(self.k[0], self.k[2].secret,
+                         'returned secret key does not match returned keypair')
+        self.assertEqual(self.k[1], self.k[2].public_key,
+                         'returned public key does not match returned keypair')

--- a/test/test_LoadKeyInformation.py
+++ b/test/test_LoadKeyInformation.py
@@ -1,0 +1,29 @@
+"""
+Test module sq_python_helpers.LoadKeyInformation
+"""
+from unittest import TestCase
+from stellar_sdk import Keypair
+
+from sq_python_helpers.LoadKeyInformation import load_key_information
+
+class LoadKeyInformationTestCase(TestCase):
+    def setUp(self) -> None:
+        self.k = load_key_information(Keypair.random().secret)
+
+    def test_return_three_items(self):
+        self.assertEqual(len(self.k), 3,
+                         'wrong number of items returned')
+
+    def test_return_expected_types(self):
+        self.assertIsInstance(self.k[0], str,
+                              'first item is not a string')
+        self.assertIsInstance(self.k[1], str,
+                              'second item is not a string')
+        self.assertIsInstance(self.k[2], Keypair,
+                              'third item is not a Keypair object')
+
+    def test_public_secret_keypair_match(self):
+        self.assertEqual(self.k[0], self.k[2].secret,
+                         'returned secret key does not match returned keypair')
+        self.assertEqual(self.k[1], self.k[2].public_key,
+                         'returned public key does not match returned keypair')

--- a/test/test_SetupServerConnection.py
+++ b/test/test_SetupServerConnection.py
@@ -1,0 +1,75 @@
+"""
+Test module sq_python_helpers.SetupServerConnection
+"""
+import json
+import requests
+import requests_mock
+from unittest import TestCase
+from stellar_sdk import Keypair, Server, Network, Account
+
+from sq_python_helpers.SetupServerConnection import setup_server_connection
+
+class SetupServerConnectionTestCase(TestCase):
+    @requests_mock.Mocker()
+    def setUp(self, m: requests_mock.Mocker) -> None:
+        with open("test/fixtures/funded_account.json", "r") as fixture_file:
+            self.funded_account = json.load(fixture_file)
+            self.account_id = self.funded_account.get("account_id")
+        with open("test/fixtures/testnet_ledger.json", "r") as fixture_file:
+            self.ledger = json.load(fixture_file)
+        m.get("https://horizon-testnet.stellar.org/ledgers?order=desc&limit=1",
+              json=self.ledger)
+        m.get("https://horizon.stellar.org/ledgers?order=desc&limit=1",
+              json=self.ledger)
+        m.get(f"https://horizon-testnet.stellar.org/accounts/{self.account_id}",
+              json=self.funded_account)
+        m.get(f"https://horizon.stellar.org/accounts/{self.account_id}",
+              json=self.funded_account)
+        self.testnet_conn = setup_server_connection(self.account_id)
+        self.mainnet_conn = setup_server_connection(self.account_id, testnet=False)
+
+    def test_return_four_items(self):
+        self.assertEqual(len(self.testnet_conn), 4,
+                         'wrong number of items returned')
+        self.assertEqual(len(self.mainnet_conn), 4,
+                         'wrong number of items returned')
+
+    def test_return_expected_types(self):
+        self.assertIsInstance(self.testnet_conn[0], Server,
+                              'first item is not a Server object')
+        self.assertIsInstance(self.mainnet_conn[0], Server,
+                              'first item is not a Server object')
+        self.assertIsInstance(self.testnet_conn[1], Account,
+                              'second item is not an Account object')
+        self.assertIsInstance(self.mainnet_conn[1], Account,
+                              'second item is not an Account object')
+        self.assertIsInstance(self.testnet_conn[2], str,
+                              'third item is not a string')
+        self.assertIsInstance(self.mainnet_conn[2], str,
+                              'third item is not a string')
+        self.assertIsInstance(self.testnet_conn[3], int,
+                              'fourth item is not an integer')
+        self.assertIsInstance(self.mainnet_conn[3], int,
+                              'fourth item is not an integer')
+
+    def test_return_main_test_details(self):
+        self.assertEqual(self.testnet_conn[0].horizon_url, "https://horizon-testnet.stellar.org",
+                         'incorrect horizon_url returned')
+        self.assertEqual(self.mainnet_conn[0].horizon_url, "https://horizon.stellar.org",
+                         'incorrect horizon_url returned')
+        self.assertEqual(self.testnet_conn[2], "Test SDF Network ; September 2015",
+                         'incorrect network passphrase returned')
+        self.assertEqual(self.mainnet_conn[2], "Public Global Stellar Network ; September 2015",
+                         'incorrect network passphrase returned')
+
+    def test_account_sequence_number(self):
+        self.assertEqual(self.testnet_conn[1].sequence, 5919212258197504,
+                         'incorrect account sequence number returned')
+        self.assertEqual(self.mainnet_conn[1].sequence, 5919212258197504,
+                         'incorrect account sequence number returned')
+
+    def test_return_base_fee(self):
+        self.assertEqual(self.testnet_conn[3], 100,
+                         'incorrect base_fee returned')
+        self.assertEqual(self.mainnet_conn[3], 100,
+                         'incorrect base_fee returned')


### PR DESCRIPTION
For Issue #6. Here's a first attempt. I've written tests for the following modules:

- FundUsingFriendbot.py
- GenerateKeypair.py
- LoadKeyInformation.py
- SetupServerConnection.py

Some questions I have after writing these tests:

- I'm having a hard time figuring out how many tests to write for each function. How do I figure out the ideal amount?
- The `GenerateKeypair.py` and `LoadKeyInformation.py` tests are nearly identical since they return the same thing. Would it make more sense to combine those tests into a single file? Or, should/could those scripts be combined?
- I'm a bit fuzzy on best practices for the `requests_mock` module. I think I've got the basics, though. How reliable is it to have a json fixture that represented a real response at some point in the past, and testing off that? Is it always preferable to use `requests_mock` rather than make actual queries (i.e. to get the `base_fee` in `SetupServerConnection.py`)?

Thanks, everyone! It's been so helpful to be able to learn from you all through this simple little project!